### PR TITLE
add "\n" to die "Usage: ..." lines

### DIFF
--- a/bin/ph
+++ b/bin/ph
@@ -61,7 +61,7 @@ exit;
 sub main {
     my $cmd = shift @ARGV || 'help';
     my $cmd_code = __PACKAGE__->can("CMD_$cmd")
-        or die "Unknown command $cmd";
+        or die "Unknown command $cmd\n";
     $cmd_code->();
 }
 
@@ -132,7 +132,7 @@ sub CMD_pull {
 
 sub CMD_pullreq {
     my ($title, $branch, $desc) = splice(@ARGV, 2);
-    $title or die "Usage: $0 pullreq tokuhirom ph 'pull req title'";
+    $title or die "Usage: $0 pullreq tokuhirom ph 'pull req title'\n";
     $branch ||= `git symbolic-ref -q HEAD` || 'master';
     $desc   ||= '';
 
@@ -161,7 +161,7 @@ sub CMD_add {
 
 sub CMD_all {
     my ($user) = shift @ARGV;
-    $user or die "Usage: $0 all tokuhirom";
+    $user or die "Usage: $0 all tokuhirom\n";
     my $res = $pithub->repos->list(user => $user);
     $res->success or die dump_content($res->content);
     $res->auto_pagination(1);
@@ -242,7 +242,7 @@ sub _get_user_repo_simple() {
 sub _get_user_repo {
     my ($cmd) = @_;
     my ($user, $repo) = _get_user_repo_simple();
-    $user // die "Usage: $0 $cmd miyagawa/Plack";
+    $user // die "Usage: $0 $cmd miyagawa/Plack\n";
     return ($user, $repo);
 }
 


### PR DESCRIPTION
...as this prevents the trailing "at line/file" message, normally useful when
something dies, but not really if we're just reminding the user of the syntax
of a particular command.
