### PR TITLE
Encode output string to console encoding

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,8 @@ requires 'Term::ReadKey';
 requires 'autodie';
 requires 'parent';
 requires 'Term::ANSIColor';
+requires 'Encode';
+requires 'Encode::Locale';
 
 on configure => sub {
     requires 'Module::Build::Tiny';

--- a/script/ph
+++ b/script/ph
@@ -15,6 +15,13 @@ use Term::ReadKey;
 use Sys::Hostname;
 use Pod::Usage;
 use Term::ANSIColor;
+use Encode ();
+use Encode::Locale;
+
+if (-t) {
+    binmode STDOUT, ":encoding(console_out)";
+    binmode STDERR, ":encoding(console_out)";
+}
 
 sub prompt {
     my ($prompt, @args) = @_;


### PR DESCRIPTION
Warnings are occurred if title of issue contains multi-byte characters.
