### PR TITLE
Changes file: Corrected date (and its format) of first release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-Revision history for Perl extension App::ph
+Revision history for Perl module App::ph
 
 {{$NEXT}}
 
@@ -37,5 +37,7 @@ Revision history for Perl extension App::ph
     - Name our token, so we can tell what/where it is from the Applications page
       (RsrchBoy)
 
-0.01    Wed Jul 18 06:17:15 2012
+0.01 2012-09-01
+
     - original version
+


### PR DESCRIPTION
Just one change here: the date of the first release.

I was going to change the distname to App::ph, since that's the convention (and CPAN ensures uniqueness of module names, but not distnames, so basing distname on module name is a good / safe approach), but noticed it was first called that and you renamed it to **ph**.

Neil
